### PR TITLE
Announcement cards newline fixes 

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -111,7 +111,7 @@
                 </div>
                 <div *ngIf="item.hasLongSummary">
                   <div class="card-body">
-                    {{item.body}}
+                    <p class="e2e-inner-html-bound" style="color: var(--card-body-text)" [innerHTML]= "item.body"></p>
                   </div>
                   <button class="card-primary-btn :inline-block" id="card-btn-1">
                     <div class="card-button-text" id="card-text-1" (click)="item.hasLongSummary = !item.hasLongSummary">
@@ -122,7 +122,7 @@
                 </div>
                 <div *ngIf="!item.hasLongSummary">
                   <div class="card-body">
-                    {{item.fullBody}}
+                    <p class="e2e-inner-html-bound" style="color: var(--card-body-text)" [innerHTML]= "item.fullBody"></p>
                   </div>
                 </div>
               </div>
@@ -139,7 +139,7 @@
                 </div>
                 <div *ngIf="item.hasLongSummary">
                   <div class="card-body">
-                    {{item.body}}
+                    <p class="e2e-inner-html-bound" style="color: var(--card-body-text)" [innerHTML]= "item.body"></p>
                   </div>
                   <button class="card-primary-btn :inline-block" id="card-btn-2">
                     <div class="card-button-text" id="card-text-2" (click)="item.hasLongSummary = !item.hasLongSummary">
@@ -150,7 +150,7 @@
                 </div>
                 <div *ngIf="!item.hasLongSummary">
                   <div class="card-body">
-                    {{item.fullBody}}
+                    <p class="e2e-inner-html-bound" style="color: var(--card-body-text)" [innerHTML]= "item.fullBody"></p>
                   </div>
                 </div>
               </div>
@@ -167,7 +167,7 @@
                 </div>
                 <div *ngIf="item.hasLongSummary">
                   <div class="card-body">
-                    {{item.body}}
+                    <p class="e2e-inner-html-bound" style="color: var(--card-body-text)" [innerHTML]= "item.body"></p>
                   </div>
                   <button class="card-primary-btn :inline-block" id="card-btn-3">
                     <div class="card-button-text" id="card-text-3" (click)="item.hasLongSummary = !item.hasLongSummary">
@@ -178,7 +178,7 @@
                 </div>
                 <div *ngIf="!item.hasLongSummary">
                   <div class="card-body">
-                    {{item.fullBody}}
+                    <p class="e2e-inner-html-bound" style="color: var(--card-body-text)" [innerHTML]= "item.fullBody"></p>
                   </div>
                 </div>
               </div>

--- a/src/app/resource-list/resource-list.component.html
+++ b/src/app/resource-list/resource-list.component.html
@@ -72,7 +72,7 @@
             </div>
           </div>
           <div class="card-body">
-            {{currentAnnoucement.body}}
+            <p class="e2e-inner-html-bound" style="color: var(--card-body-text)" [innerHTML]= "currentAnnoucement.body"></p>
           </div>
         </div>
       </div>

--- a/src/app/resource-list/resource-list.component.ts
+++ b/src/app/resource-list/resource-list.component.ts
@@ -208,7 +208,7 @@ export class ResourceListComponent implements OnInit {
   openCard(announcement: Announcement) {
     this.currentAnnoucement.title = announcement.title;
     this.currentAnnoucement.date = '12/2/2019';
-    this.currentAnnoucement.body = announcement.body;
+    this.currentAnnoucement.body = announcement.fullBody;
     this.cardView = true;
   }
 

--- a/src/app/user/user.component.ts
+++ b/src/app/user/user.component.ts
@@ -410,8 +410,13 @@ export class UserComponent implements OnInit {
   }
 
   announcementTextBodyChangeHandler(event: any) {
-    this.annoucementBody = event.target.value;
+    console.log(event.target.value);
+    this.annoucementBody = this.announcementTextBodyNewLineFormatter(event.target.value);
     this.announcementBodyAlert = false;
+  }
+
+  announcementTextBodyNewLineFormatter(body: string): string {
+    return body.replace(/\n\r?/g, '<br/>');
   }
 
   clearForm() {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,7 @@
   --primary-option: #245980;
   --primary-option-faded: #0e5e976e;
   --secondary-option: #A8B1B8;
+
 }
 .container-fluid{
   padding-left:  0;


### PR DESCRIPTION
This PR fixes new lines in announcement cards so cards can show paragraphs. Also, in the future, we can add things like tab and other HTML tags to our formatter. For now, it only replaces newline and replaces it with <br>. 

See below for result:
<img width="752" alt="Screen Shot 2020-03-22 at 7 20 15 PM" src="https://user-images.githubusercontent.com/31574594/77274017-2c170880-6c72-11ea-999a-5242508d1861.png">
