### PR TITLE
0322 - Document storage hotfix

### DIFF
--- a/src/app/resource-list/resource-list.component.ts
+++ b/src/app/resource-list/resource-list.component.ts
@@ -133,7 +133,6 @@ export class ResourceListComponent implements OnInit {
       }
 
       this.committeeReports.sort(function (a, b) {
-        console.log('called here');
         if (a.monthInt < b.monthInt) {
           return -1;
         }

--- a/src/app/resources/resources.component.html
+++ b/src/app/resources/resources.component.html
@@ -1,3 +1,4 @@
+<!--suppress ALL -->
 <div class="resources-view">
   <div class="resources-main-container">
     <div class="navbar-spacer"></div>
@@ -74,9 +75,12 @@
                                 report.monthDate==='March' ||
                                 report.monthDate==='April'">
                               <span class="report-title month-header">{{report.monthDate}}</span><br>
-                              <strong><u><a href="{{report.minLink}}" id="link">{{report.minutes}}</a></u></strong><br>
-                              <strong><u><a href="{{report.finLink}}"
-                                            id="link">{{report.financialReport}}</a></u></strong>
+                              <div *ngIf="report.financialReport">
+                                <strong><u><a href="{{report.finLink}}" target="_blank" id="link">Financial Report</a></u></strong><br>
+                              </div>
+                              <div *ngIf="report.minutes">
+                                <strong><u><a href="{{report.minLink}}" target="_blank" id="link">Committee Minutes</a></u></strong>
+                              </div>
                               <br><br>
                             </div>
                           </div>
@@ -96,9 +100,12 @@
                                 report.monthDate==='July' ||
                                 report.monthDate==='August'">
                               <span class="report-title month-header">{{report.monthDate}}</span><br>
-                              <strong><u><a href="{{report.minLink}}" id="link">{{report.minutes}}</a></u></strong><br>
-                              <strong><u><a href="{{report.finLink}}"
-                                            id="link">{{report.financialReport}}</a></u></strong>
+                              <div *ngIf="report.financialReport">
+                                <strong><u><a href="{{report.finLink}}" target="_blank" id="link">Financial Report</a></u></strong><br>
+                              </div>
+                              <div *ngIf="report.minutes">
+                                <strong><u><a href="{{report.minLink}}" target="_blank" id="link">Committee Minutes</a></u></strong>
+                              </div>
                               <br><br>
                             </div>
                           </div>
@@ -118,9 +125,12 @@
                                   report.monthDate==='November' ||
                                   report.monthDate==='December'">
                               <span class="report-title month-header">{{report.monthDate}}</span><br>
-                              <strong><u><a href="{{report.minLink}}" id="link">{{report.minutes}}</a></u></strong><br>
-                              <strong><u><a href="{{report.finLink}}"
-                                            id="link">{{report.financialReport}}</a></u></strong>
+                              <div *ngIf="report.financialReport">
+                                <strong><u><a href="{{report.finLink}}" target="_blank" id="link">Financial Report</a></u></strong><br>
+                              </div>
+                              <div *ngIf="report.minutes">
+                                <strong><u><a href="{{report.minLink}}" target="_blank" id="link">Committee Minutes</a></u></strong>
+                              </div>
                               <br><br>
                             </div>
                           </div>

--- a/src/app/resources/resources.component.ts
+++ b/src/app/resources/resources.component.ts
@@ -142,7 +142,7 @@ export class ResourcesComponent implements OnInit {
 
     this.resourceService.getMonthlyReports().subscribe(data => {
       this.monthlyReports = data.map(e => {
-        console.log('retrieved monthly reports from firestore');
+        console.log('retrieved monthly reports from firestore: ' + e.payload.doc.id);
         return {
           id: e.payload.doc.id,
           ...e.payload.doc.data()

--- a/src/app/user/user.component.ts
+++ b/src/app/user/user.component.ts
@@ -159,7 +159,7 @@ export class UserComponent implements OnInit {
       last_name: ['', Validators.required],
       email: ['', [Validators.required, Validators.email]],
       phone: ['', [Validators.required, Validators.pattern('^(1?-?[(]?(-?\\d{3})[)]?-?)?(\\d{3})(-?\\d{4})$')]],
-      commitments: ['',[Validators.required]]
+      commitments: ['', [Validators.required]]
     });
 
   }
@@ -253,7 +253,7 @@ export class UserComponent implements OnInit {
       } else if (this.resource.toString() === this.resources[2]) {
         const year = new Date().getFullYear().toString();
         console.log(this.basePath.toString() + ' and ' + this.report.toString());
-        this.title = this.report;
+        this.title = this.basePath + '_' + this.report;
         this.ref = this.afStorage.ref('/Monthly Reports/' + this.title.toString());
         this.task = this.ref.put(this.fileData);
         this.uploadProgress = this.task.percentageChanges();


### PR DESCRIPTION
Documents had duplicate names causing storage failure. Re-introduced name for monthly minutes and financial documents as "month_committee_minutes" and "month_financial_report"